### PR TITLE
Customizations settings dev

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.1",
         "react-bootstrap-icons": "^1.10.3",
+        "react-bootstrap-typeahead": "^6.3.2",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
         "web-vitals": "^2.1.4"
@@ -2207,6 +2208,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2398,6 +2404,11 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -2890,6 +2901,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3187,6 +3203,32 @@
         "react": ">=16.8.6"
       }
     },
+    "node_modules/react-bootstrap-typeahead": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-6.3.2.tgz",
+      "integrity": "sha512-N5Mb0WlSSMcD7Z0pcCypILgIuECybev0hl4lsnCa5lbXTnN4QdkuHLGuTLSlXBwm1ZMFpOc2SnsdSRgeFiF+Ow==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@popperjs/core": "^2.10.2",
+        "@restart/hooks": "^0.4.0",
+        "classnames": "^2.2.0",
+        "fast-deep-equal": "^3.1.1",
+        "invariant": "^2.2.1",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.5.8",
+        "react-overlays": "^5.2.0",
+        "react-popper": "^2.2.5",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "warning": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -3199,6 +3241,11 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -3208,6 +3255,39 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
     },
     "node_modules/react-router": {
       "version": "6.18.0",
@@ -3326,6 +3406,14 @@
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "node_modules/set-function-length": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.1",
     "react-bootstrap-icons": "^1.10.3",
+    "react-bootstrap-typeahead": "^6.3.2",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
     "web-vitals": "^2.1.4"
@@ -42,5 +43,5 @@
     "@vitejs/plugin-react": "^4.2.1",
     "vite": "^5.0.11"
   },
-  "type":"module"
+  "type": "module"
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Signin from "./pages/SignPages/Signin.jsx";
 import BasePage from "./pages/BasePage.jsx";
 
 import ProfileEdit from "./Components/Settings/Profile/ProfileEdit.jsx";
+import CustomizationsEdit from "./Components/Settings/Customizations/CustomizationsEdit.jsx";
 
 function App() {
   return (
@@ -24,7 +25,7 @@ function App() {
             <Route index element={<ArticleView />} />
             <Route path=":name" element={<ArticleView />} />
           </Route>
-          <Route path="profile-settings" element={<ProfileEdit />} />
+          <Route path="profile-settings" element={<><CustomizationsEdit/></>} />
           <Route
             path="*"
             element={<h1 className="text-center">404 - Page Not Found</h1>}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,7 @@ function App() {
             <Route index element={<ArticleView />} />
             <Route path=":name" element={<ArticleView />} />
           </Route>
-          <Route path="profile-settings" element={<><CustomizationsEdit/></>} />
+          <Route path="profile-settings" element={<><ProfileEdit/><CustomizationsEdit/></>} />
           <Route
             path="*"
             element={<h1 className="text-center">404 - Page Not Found</h1>}

--- a/frontend/src/Components/Footer/Footer.jsx
+++ b/frontend/src/Components/Footer/Footer.jsx
@@ -2,7 +2,7 @@ import { Container, Button, Stack } from "react-bootstrap";
 
 export default function Footer() {
   return (
-    <Container fluid className="bg-primary border-top py-2 mt-auto">
+    <Container fluid className="bg-primary border-top py-2 mt-auto" style={{flex:"0"}}>
       <Stack direction="horizontal" gap={5} className=" justify-content-center">
         <Button className="text-white fw-semibold" href="/">
           Home
@@ -59,13 +59,13 @@ export default function Footer() {
               r="44.899"
               gradientUnits="userSpaceOnUse"
             >
-              <stop offset="0" stop-color="#fd5"></stop>
-              <stop offset=".328" stop-color="#ff543f"></stop>
-              <stop offset=".348" stop-color="#fc5245"></stop>
-              <stop offset=".504" stop-color="#e64771"></stop>
-              <stop offset=".643" stop-color="#d53e91"></stop>
-              <stop offset=".761" stop-color="#cc39a4"></stop>
-              <stop offset=".841" stop-color="#c837ab"></stop>
+              <stop offset="0" stopColor="#fd5"></stop>
+              <stop offset=".328" stopColor="#ff543f"></stop>
+              <stop offset=".348" stopColor="#fc5245"></stop>
+              <stop offset=".504" stopColor="#e64771"></stop>
+              <stop offset=".643" stopColor="#d53e91"></stop>
+              <stop offset=".761" stopColor="#cc39a4"></stop>
+              <stop offset=".841" stopColor="#c837ab"></stop>
             </radialGradient>
             <path
               fill="url(#yOrnnhliCrdS2gy~4tD8ma_Xy10Jcu1L2Su_gr1)"
@@ -79,8 +79,8 @@ export default function Footer() {
               gradientTransform="matrix(1 0 0 .6663 0 1.849)"
               gradientUnits="userSpaceOnUse"
             >
-              <stop offset="0" stop-color="#4168c9"></stop>
-              <stop offset=".999" stop-color="#4168c9" stop-opacity="0"></stop>
+              <stop offset="0" stopColor="#4168c9"></stop>
+              <stop offset=".999" stopColor="#4168c9" stopOpacity="0"></stop>
             </radialGradient>
             <path
               fill="url(#yOrnnhliCrdS2gy~4tD8mb_Xy10Jcu1L2Su_gr2)"
@@ -117,8 +117,8 @@ export default function Footer() {
               y2="23.508"
               gradientUnits="userSpaceOnUse"
             >
-              <stop offset="0" stop-color="#4c4c4c"></stop>
-              <stop offset="1" stop-color="#343434"></stop>
+              <stop offset="0" stopColor="#4c4c4c"></stop>
+              <stop offset="1" stopColor="#343434"></stop>
             </linearGradient>
             <path
               fill="url(#rL2wppHyxHVbobwndsT6Ca_AZOZNnY73haj_gr1)"

--- a/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
+++ b/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
@@ -38,14 +38,11 @@ export default function CustomizationsEdit({}) {
   // keep track of chnanges
   const [isDataChanged, setIsDataChanged] = useState(false);
 
-
   const [editable, setEditable] = useState({
     interest_areas: false,
     article_level: false,
     technologies: false,
   });
-
-
 
   // handle submit
   const handleSubmit = (e) => {
@@ -84,7 +81,6 @@ export default function CustomizationsEdit({}) {
               onChange={(selected) => {
                 setCustData({ ...custData, article_level: selected });
                 setIsDataChanged(true);
-
               }}
               setEditable={setEditable}
               editable={editable}
@@ -101,7 +97,6 @@ export default function CustomizationsEdit({}) {
               onChange={(selected) => {
                 setCustData({ ...custData, technologies: selected });
                 setIsDataChanged(true);
-
               }}
               onInputChange={(e) => console.log(e)}
               setEditable={setEditable}
@@ -139,18 +134,16 @@ export default function CustomizationsEdit({}) {
           </Stack>
         )}
       </Form>
-      
     </Container>
   );
 }
-
 
 const AreasOfInterest = ({
   selectedState,
   options,
   onChange,
   editable,
-  setEditable
+  setEditable,
 }) => {
   return (
     <>
@@ -172,15 +165,6 @@ const AreasOfInterest = ({
                 : "bg-uneditable-input"
             }`}
             disabled={!editable.interest_areas}
-            renderMenu={(results, menuProps) => (
-              <Menu {...menuProps}>
-                {results.map((result,index) => (
-                  <MenuItem option={result} position={index} style={{background: "black"}}>
-                    {result}
-                  </MenuItem>
-                ))}
-              </Menu>
-            )}
           />
           <Button
             title="Edit"
@@ -253,7 +237,7 @@ const TechnologiesOfInterest = ({
   onChange,
   editable,
   setEditable,
-  setIsDataChanged
+  setIsDataChanged,
 }) => {
   return (
     <>

--- a/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
+++ b/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Container,
   Form,
@@ -8,24 +8,25 @@ import {
   Button,
   Stack,
 } from "react-bootstrap";
+import { PencilFill } from "react-bootstrap-icons";
 import "../Settings.scss";
-
+import { Typeahead } from "react-bootstrap-typeahead";
 export default function CustomizationsEdit({}) {
   //customization data
   const [custData, setCustData] = useState({
-    interest_area: "",
-    article_level: "",
-    technologies: "",
+    interest_areas: [],
+    article_level: [],
+    technologies: [],
   });
 
   //state of options for each data
-  const [interestAreaOptions, setInterestAreaOptions] = useState([]);
+  const [interestAreasOptions, setInterestAreasOptions] = useState([]);
   const [articleLevelOptions, setArticleLevelOptions] = useState([]);
   const [technologiesOptions, setTechnologiesOptions] = useState([]);
 
   //simulating grabbing options from backend (if we are doing that)
   useEffect(() => {
-    setInterestAreaOptions([
+    setInterestAreasOptions([
       "Artificial Intelligence",
       "Machine Learning",
       "Web Development",
@@ -36,6 +37,12 @@ export default function CustomizationsEdit({}) {
 
   // keep track of chnanges
   const [isDataChanged, setIsDataChanged] = useState(false);
+
+  const [editable, setEditable] = useState({
+    interest_areas: false,
+    article_level: false,
+    technologies: false,
+  });
 
   // handle input entered
   const handleInput = (e) => {
@@ -52,6 +59,7 @@ export default function CustomizationsEdit({}) {
   // handle submit
   const handleSubmit = (e) => {
     e.preventDefault();
+    console.log(custData);
   };
 
   return (
@@ -63,58 +71,46 @@ export default function CustomizationsEdit({}) {
         {/*Area of Interest */}
         <Row xs={12} className="my-4">
           <Col>
-            <Form.Label>
-              What is your area of interest in Computer Science?
-            </Form.Label>
-            <Form.Group>
-              <InputGroup hasValidation>
-                <Select
-                  name={"interest_area"}
-                  value={custData.interest_area}
-                  options={interestAreaOptions}
-                  onChange={handleInput}
-                />
-              </InputGroup>
-            </Form.Group>
+            <AreasOfInterest
+              selectedState={custData.interest_areas}
+              options={interestAreasOptions}
+              onChange={(selected) => {
+                setCustData({ ...custData, interest_areas: selected });
+              }}
+              setEditable={setEditable}
+              editable={editable}
+            />
           </Col>
         </Row>
         {/*Difficulty Level */}
 
         <Row xs={12} className="my-4">
           <Col>
-            <Form.Label>
-              What level are you looking for in the article content?
-            </Form.Label>
-            <Form.Group>
-              <InputGroup hasValidation>
-                <Select
-                  name={"article_level"}
-                  value={custData.article_level}
-                  options={articleLevelOptions}
-                  onChange={handleInput}
-                />
-              </InputGroup>
-            </Form.Group>
+            <ArticleLevel
+              selectedState={custData.article_level}
+              options={articleLevelOptions}
+              onChange={(selected) => {
+                setCustData({ ...custData, article_level: selected });
+              }}
+              setEditable={setEditable}
+              editable={editable}
+            />
           </Col>
         </Row>
         {/*Interest in technologies*/}
 
         <Row xs={12} className="my-4">
           <Col>
-            <Form.Label>
-              Which programming languages or technologies are you interested in
-              exploring?
-            </Form.Label>
-            <Form.Group>
-              <InputGroup hasValidation>
-                <Select
-                  name={"technologies"}
-                  value={custData.technologies}
-                  options={technologiesOptions}
-                  onChange={handleInput}
-                />
-              </InputGroup>
-            </Form.Group>
+            <TechnologiesOfInterest
+              selectedState={custData.technologies}
+              options={technologiesOptions}
+              onChange={(selected) => {
+                setCustData({ ...custData, technologies: selected });
+              }}
+              onInputChange={(e) => console.log(e)}
+              setEditable={setEditable}
+              editable={editable}
+            />
           </Col>
         </Row>
         {isDataChanged && (
@@ -151,21 +147,144 @@ export default function CustomizationsEdit({}) {
   );
 }
 
-//Select component
-const Select = ({ value, options, name, onChange }) => {
+const AreasOfInterest = ({
+  selectedState,
+  options,
+  onChange,
+  editable,
+  setEditable,
+}) => {
   return (
-    <Form.Select
-      defaultValue={value}
-      name={name}
-      className={`border border-dark bg-editable-input`}
-      onChange={onChange}
-    >
-      <option value="">Select an option</option>
-      {options.map((opText) => (
-        <option key={opText} value={opText}>
-          {opText}
-        </option>
-      ))}
-    </Form.Select>
+    <>
+      <Form.Label>
+        What are your areas of interest in Computer Science?
+      </Form.Label>
+      <Form.Group>
+        <InputGroup hasValidation>
+          <Typeahead
+            id="areas-of-interest"
+            multiple
+            onChange={onChange}
+            options={options}
+            placeholder="Choose your areas of interest"
+            selected={selectedState}
+            className={`border border-dark rounded-start border-end-0 ${
+              editable.interest_areas
+                ? "bg-editable-input"
+                : "bg-uneditable-input"
+            }`}
+            disabled={!editable.interest_areas}
+          />
+          <Button
+            title="Edit"
+            disabled={editable.interest_areas}
+            className={`bg-transparent border-start-0 border-dark edit-button-hover-light ${
+              !editable.interest_areas
+                ? "enable-edit-color"
+                : "disable-edit-color"
+            }`}
+            onClick={() => setEditable({ ...editable, interest_areas: true })}
+          >
+            <PencilFill />
+          </Button>
+        </InputGroup>
+      </Form.Group>
+    </>
+  );
+};
+
+const ArticleLevel = ({
+  selectedState,
+  options,
+  onChange,
+  editable,
+  setEditable,
+}) => {
+  return (
+    <>
+      <Form.Label>
+        What level are you looking for in the article content?
+      </Form.Label>
+      <Form.Group>
+        <InputGroup hasValidation>
+          <Typeahead
+            id="article-level"
+            single
+            onChange={onChange}
+            options={options}
+            placeholder="Choose your article level"
+            selected={selectedState}
+            inputProps={{
+              className: `border border-dark rounded-start border-end-0 ${
+                editable.article_level
+                  ? "bg-editable-input"
+                  : "bg-uneditable-input"
+              }`,
+            }}
+          />
+          <Button
+            title="Edit"
+            disabled={editable.article_level}
+            className={`bg-transparent border-start-0 border-dark edit-button-hover-light ${
+              !editable.article_level
+                ? "enable-edit-color"
+                : "disable-edit-color"
+            }`}
+            onClick={() => setEditable({ ...editable, article_level: true })}
+          >
+            <PencilFill />
+          </Button>
+        </InputGroup>
+      </Form.Group>
+    </>
+  );
+};
+
+const TechnologiesOfInterest = ({
+  selectedState,
+  options,
+  onChange,
+  editable,
+  setEditable,
+}) => {
+  return (
+    <>
+      <Form.Label>
+        Which programming languages or technologies are you interested in
+        exploring?
+      </Form.Label>
+      <Form.Group>
+        <InputGroup hasValidation>
+          <Typeahead
+            id="technologies-of-interest"
+            multiple
+            onChange={onChange}
+            options={options}
+            placeholder="Choose the technologies you're interested in"
+            selected={selectedState}
+            className={`border border-dark rounded-start border-end-0 ${
+              editable.technologies
+                ? "bg-editable-input"
+                : "bg-uneditable-input"
+            }`}
+            disabled={!editable.technologies}
+          />
+          <Button
+            title="Edit"
+            disabled={editable.technologies}
+            className={`bg-transparent border-start-0 border-dark edit-button-hover-light ${
+              !editable.technologies
+                ? "enable-edit-color"
+                : "disable-edit-color"
+            }`}
+            onClick={() => {
+              setEditable({ ...editable, technologies: true });
+            }}
+          >
+            <PencilFill />
+          </Button>
+        </InputGroup>
+      </Form.Group>
+    </>
   );
 };

--- a/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
+++ b/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
@@ -1,0 +1,171 @@
+import { useState, useRef, useEffect } from "react";
+import {
+  Container,
+  Form,
+  Row,
+  Col,
+  InputGroup,
+  Button,
+  Stack,
+} from "react-bootstrap";
+import "../Settings.scss";
+
+export default function CustomizationsEdit({}) {
+  //customization data
+  const [custData, setCustData] = useState({
+    interest_area: "",
+    article_level: "",
+    technologies: "",
+  });
+
+  //state of options for each data
+  const [interestAreaOptions, setInterestAreaOptions] = useState([]);
+  const [articleLevelOptions, setArticleLevelOptions] = useState([]);
+  const [technologiesOptions, setTechnologiesOptions] = useState([]);
+
+  //simulating grabbing options from backend (if we are doing that)
+  useEffect(() => {
+    setInterestAreaOptions([
+      "Artificial Intelligence",
+      "Machine Learning",
+      "Web Development",
+    ]);
+    setArticleLevelOptions(["Beginner", "Proficient", "Advanced"]);
+    setTechnologiesOptions(["Python", "C", "C++"]);
+  }, []);
+
+  // keep track of chnanges
+  const [isDataChanged, setIsDataChanged] = useState(false);
+
+  // handle input entered
+  const handleInput = (e) => {
+    const { name, value } = e.target;
+
+    setIsDataChanged(true);
+    console.log(custData);
+    setCustData({
+      ...custData,
+      [name]: value,
+    });
+  };
+
+  // handle submit
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+
+  return (
+    <Container className="my-3">
+      <Form noValidate onSubmit={handleSubmit}>
+        <h4 className="ps-2 py-1 border-start border-4 border-primary">
+          Customize your choice of articles
+        </h4>
+        {/*Area of Interest */}
+        <Row xs={12} className="my-4">
+          <Col>
+            <Form.Label>
+              What is your area of interest in Computer Science?
+            </Form.Label>
+            <Form.Group>
+              <InputGroup hasValidation>
+                <Select
+                  name={"interest_area"}
+                  value={custData.interest_area}
+                  options={interestAreaOptions}
+                  onChange={handleInput}
+                />
+              </InputGroup>
+            </Form.Group>
+          </Col>
+        </Row>
+        {/*Difficulty Level */}
+
+        <Row xs={12} className="my-4">
+          <Col>
+            <Form.Label>
+              What level are you looking for in the article content?
+            </Form.Label>
+            <Form.Group>
+              <InputGroup hasValidation>
+                <Select
+                  name={"article_level"}
+                  value={custData.article_level}
+                  options={articleLevelOptions}
+                  onChange={handleInput}
+                />
+              </InputGroup>
+            </Form.Group>
+          </Col>
+        </Row>
+        {/*Interest in technologies*/}
+
+        <Row xs={12} className="my-4">
+          <Col>
+            <Form.Label>
+              Which programming languages or technologies are you interested in
+              exploring?
+            </Form.Label>
+            <Form.Group>
+              <InputGroup hasValidation>
+                <Select
+                  name={"technologies"}
+                  value={custData.technologies}
+                  options={technologiesOptions}
+                  onChange={handleInput}
+                />
+              </InputGroup>
+            </Form.Group>
+          </Col>
+        </Row>
+        {isDataChanged && (
+          <Stack
+            direction="horizontal"
+            gap={3}
+            className="mt-3 justify-content-end"
+          >
+            <div>
+              <Button
+                className="border-0 text-dark fw-medium"
+                style={{ backgroundColor: "#24BEEF" }}
+                type="submit"
+              >
+                Save
+              </Button>
+            </div>
+            <div>
+              <Button
+                className="border-0 text-dark fw-medium"
+                style={{ backgroundColor: "#B9B2B2" }}
+                onClick={() => {
+                  setIsDataChanged(false);
+                  window.location.reload();
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </Stack>
+        )}
+      </Form>
+    </Container>
+  );
+}
+
+//Select component
+const Select = ({ value, options, name, onChange }) => {
+  return (
+    <Form.Select
+      defaultValue={value}
+      name={name}
+      className={`border border-dark bg-editable-input`}
+      onChange={onChange}
+    >
+      <option value="">Select an option</option>
+      {options.map((opText) => (
+        <option key={opText} value={opText}>
+          {opText}
+        </option>
+      ))}
+    </Form.Select>
+  );
+};

--- a/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
+++ b/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
@@ -10,7 +10,7 @@ import {
 } from "react-bootstrap";
 import { PencilFill } from "react-bootstrap-icons";
 import "../Settings.scss";
-import { Typeahead } from "react-bootstrap-typeahead";
+import { Menu, MenuItem, Typeahead } from "react-bootstrap-typeahead";
 export default function CustomizationsEdit({}) {
   //customization data
   const [custData, setCustData] = useState({
@@ -38,23 +38,14 @@ export default function CustomizationsEdit({}) {
   // keep track of chnanges
   const [isDataChanged, setIsDataChanged] = useState(false);
 
+
   const [editable, setEditable] = useState({
     interest_areas: false,
     article_level: false,
     technologies: false,
   });
 
-  // handle input entered
-  const handleInput = (e) => {
-    const { name, value } = e.target;
 
-    setIsDataChanged(true);
-    console.log(custData);
-    setCustData({
-      ...custData,
-      [name]: value,
-    });
-  };
 
   // handle submit
   const handleSubmit = (e) => {
@@ -76,6 +67,7 @@ export default function CustomizationsEdit({}) {
               options={interestAreasOptions}
               onChange={(selected) => {
                 setCustData({ ...custData, interest_areas: selected });
+                setIsDataChanged(true);
               }}
               setEditable={setEditable}
               editable={editable}
@@ -91,6 +83,8 @@ export default function CustomizationsEdit({}) {
               options={articleLevelOptions}
               onChange={(selected) => {
                 setCustData({ ...custData, article_level: selected });
+                setIsDataChanged(true);
+
               }}
               setEditable={setEditable}
               editable={editable}
@@ -106,6 +100,8 @@ export default function CustomizationsEdit({}) {
               options={technologiesOptions}
               onChange={(selected) => {
                 setCustData({ ...custData, technologies: selected });
+                setIsDataChanged(true);
+
               }}
               onInputChange={(e) => console.log(e)}
               setEditable={setEditable}
@@ -143,16 +139,18 @@ export default function CustomizationsEdit({}) {
           </Stack>
         )}
       </Form>
+      
     </Container>
   );
 }
+
 
 const AreasOfInterest = ({
   selectedState,
   options,
   onChange,
   editable,
-  setEditable,
+  setEditable
 }) => {
   return (
     <>
@@ -174,6 +172,15 @@ const AreasOfInterest = ({
                 : "bg-uneditable-input"
             }`}
             disabled={!editable.interest_areas}
+            renderMenu={(results, menuProps) => (
+              <Menu {...menuProps}>
+                {results.map((result,index) => (
+                  <MenuItem option={result} position={index} style={{background: "black"}}>
+                    {result}
+                  </MenuItem>
+                ))}
+              </Menu>
+            )}
           />
           <Button
             title="Edit"
@@ -246,6 +253,7 @@ const TechnologiesOfInterest = ({
   onChange,
   editable,
   setEditable,
+  setIsDataChanged
 }) => {
   return (
     <>

--- a/frontend/src/Components/Settings/Settings.scss
+++ b/frontend/src/Components/Settings/Settings.scss
@@ -24,3 +24,6 @@
 .disable-edit-color {
   color: gray !important;
 }
+
+
+

--- a/frontend/src/scss/_typeahead_override.scss
+++ b/frontend/src/scss/_typeahead_override.scss
@@ -13,14 +13,13 @@ $rbt-box-shadow-color: $focus-ring-color;
 $rbt-background-color-disabled: #e9ecef;
 $rbt-background-color: #2d2626;
 
-.bg-editable-input > .rbt-input-multi{
-  background-color: #2d2626  !important;
+.bg-editable-input > .rbt-input-multi {
+  background-color: #2d2626 !important;
   border-width: 0;
-  input{
+  input {
     color: white !important;
   }
 }
-
 
 //typeahead token
 $rbt-token-background-color: grey;
@@ -30,99 +29,5 @@ $rbt-color-disabled: #495057 !default;
 $rbt-color-white: #fff !default;
 
 
-
-/**
- * Token
- */
-$rbt-token-background-color: #e7f4ff !default;
-$rbt-token-color: $rbt-color-primary !default;
-
-$rbt-token-disabled-background-color: rgba(0, 0, 0, 0.1) !default;
-$rbt-token-disabled-color: $rbt-color-disabled !default;
-
-$rbt-token-active-background-color: $rbt-color-primary !default;
-$rbt-token-active-color: $rbt-color-white !default;
-
-.rbt-token {
-  background-color: $rbt-token-background-color;
-  border: 0;
-  border-radius: 0.25rem;
-  color: $rbt-token-color;
-  display: inline-flex;
-  line-height: 1rem;
-  // TODO: Use `gap` when it's better supported
-  margin: 1px 3px 2px 0;
-
-  .rbt-token-label {
-    padding: 0.25rem 0.5rem;
-
-    &:not(:last-child) {
-      padding-right: 0.25rem;
-    }
-  }
-
-  &-disabled {
-    background-color: $rbt-token-disabled-background-color;
-    color: $rbt-token-disabled-color;
-    pointer-events: none;
-  }
-
-  &-removeable {
-    cursor: pointer;
-  }
-
-  &-active {
-    background-color: $rbt-token-active-background-color;
-    color: $rbt-token-active-color;
-    outline: none;
-    text-decoration: none;
-  }
-
-  & &-remove-button {
-    // Hide Bootstrap close button image
-    background-image: none;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-    // Override Bootstrap button shadow
-    box-shadow: none;
-    color: inherit;
-    display: flex;
-    justify-content: center;
-    font-size: inherit;
-    font-weight: normal;
-    opacity: 1;
-    outline: none;
-    padding: 0.25rem 0.5rem;
-    padding-left: 0;
-    text-shadow: none;
-
-    .rbt-close-content {
-      // Override `display: none` in BS5 styles.
-      display: block;
-    }
-  }
-}
-
-/**
- * Loader + CloseButton container
- */
-.rbt-aux {
-  align-items: center;
-  display: flex;
-  bottom: 0;
-  justify-content: center;
-  pointer-events: none; /* Don't block clicks on the input */
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 2rem;
-
-  &-lg {
-    width: 3rem;
-  }
-
-  & .rbt-close {
-    margin-top: -0.25rem;
-    pointer-events: auto; /* Override pointer-events: none; above */
-  }
-}
+@import "react-bootstrap-typeahead/css/Typeahead.scss";
+@import "react-bootstrap-typeahead/css/Typeahead.bs5.scss";

--- a/frontend/src/scss/_typeahead_override.scss
+++ b/frontend/src/scss/_typeahead_override.scss
@@ -1,0 +1,128 @@
+@import "bootstrap/scss/bootstrap-grid";
+@import "bootstrap/scss/variables";
+
+//typeahead override
+
+/**
+ * Multi-select Input
+ */
+$rbt-background-color-disabled: #e9ecef !default;
+$rbt-border-color-focus: #80bdff !default;
+$rbt-border-color-focus: $input-focus-border-color;
+$rbt-box-shadow-color: $focus-ring-color;
+$rbt-background-color-disabled: #e9ecef;
+$rbt-background-color: #2d2626;
+
+.bg-editable-input > .rbt-input-multi{
+  background-color: #2d2626  !important;
+  border-width: 0;
+  input{
+    color: white !important;
+  }
+}
+
+
+//typeahead token
+$rbt-token-background-color: grey;
+$rbt-color-primary: black;
+$rbt-token-color: white;
+$rbt-color-disabled: #495057 !default;
+$rbt-color-white: #fff !default;
+
+
+
+/**
+ * Token
+ */
+$rbt-token-background-color: #e7f4ff !default;
+$rbt-token-color: $rbt-color-primary !default;
+
+$rbt-token-disabled-background-color: rgba(0, 0, 0, 0.1) !default;
+$rbt-token-disabled-color: $rbt-color-disabled !default;
+
+$rbt-token-active-background-color: $rbt-color-primary !default;
+$rbt-token-active-color: $rbt-color-white !default;
+
+.rbt-token {
+  background-color: $rbt-token-background-color;
+  border: 0;
+  border-radius: 0.25rem;
+  color: $rbt-token-color;
+  display: inline-flex;
+  line-height: 1rem;
+  // TODO: Use `gap` when it's better supported
+  margin: 1px 3px 2px 0;
+
+  .rbt-token-label {
+    padding: 0.25rem 0.5rem;
+
+    &:not(:last-child) {
+      padding-right: 0.25rem;
+    }
+  }
+
+  &-disabled {
+    background-color: $rbt-token-disabled-background-color;
+    color: $rbt-token-disabled-color;
+    pointer-events: none;
+  }
+
+  &-removeable {
+    cursor: pointer;
+  }
+
+  &-active {
+    background-color: $rbt-token-active-background-color;
+    color: $rbt-token-active-color;
+    outline: none;
+    text-decoration: none;
+  }
+
+  & &-remove-button {
+    // Hide Bootstrap close button image
+    background-image: none;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    // Override Bootstrap button shadow
+    box-shadow: none;
+    color: inherit;
+    display: flex;
+    justify-content: center;
+    font-size: inherit;
+    font-weight: normal;
+    opacity: 1;
+    outline: none;
+    padding: 0.25rem 0.5rem;
+    padding-left: 0;
+    text-shadow: none;
+
+    .rbt-close-content {
+      // Override `display: none` in BS5 styles.
+      display: block;
+    }
+  }
+}
+
+/**
+ * Loader + CloseButton container
+ */
+.rbt-aux {
+  align-items: center;
+  display: flex;
+  bottom: 0;
+  justify-content: center;
+  pointer-events: none; /* Don't block clicks on the input */
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 2rem;
+
+  &-lg {
+    width: 3rem;
+  }
+
+  & .rbt-close {
+    margin-top: -0.25rem;
+    pointer-events: auto; /* Override pointer-events: none; above */
+  }
+}

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -7,3 +7,4 @@ $dropdown-bg: #4a4848;
 $dropdown-color: white;
 $dropdown-link-color: white;
 $dropdown-link-hover-bg: #8c8888;
+$dropdown-link-disabled-color: #8c8888;

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -3,3 +3,7 @@ $primary: #f65757;
 $secondary: #228b22;
 $form-select-indicator-color: #FFFF;
 
+$dropdown-bg: #4a4848;
+$dropdown-color: white;
+$dropdown-link-color: white;
+$dropdown-link-hover-bg: #8c8888;

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -1,2 +1,3 @@
 $primary: #f65757;
 $secondary: #228b22;
+$form-select-indicator-color: #FFFF;

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -1,3 +1,5 @@
+
 $primary: #f65757;
 $secondary: #228b22;
 $form-select-indicator-color: #FFFF;
+

--- a/frontend/src/scss/custom.scss
+++ b/frontend/src/scss/custom.scss
@@ -1,11 +1,10 @@
 @import './variables';
-
-
+@import './typeahead_override';
 .form-control:valid {
   background-image: none !important;
 }
 
 
-@import "../../node_modules/bootstrap/scss/bootstrap";
-
-
+@import "bootstrap/scss/bootstrap";
+@import "react-bootstrap-typeahead/css/Typeahead.scss";
+@import "react-bootstrap-typeahead/css/Typeahead.bs5.scss";

--- a/frontend/src/scss/custom.scss
+++ b/frontend/src/scss/custom.scss
@@ -1,10 +1,7 @@
-@import './variables';
-@import './typeahead_override';
+@import "./variables";
+@import "./typeahead_override";
 .form-control:valid {
   background-image: none !important;
 }
 
-
 @import "bootstrap/scss/bootstrap";
-@import "react-bootstrap-typeahead/css/Typeahead.scss";
-@import "react-bootstrap-typeahead/css/Typeahead.bs5.scss";


### PR DESCRIPTION
I have implemented the customizations form section for the user settings.

I used the package React Bootstrap Typeahead to implement selecting multiple areas of interest/technologies of interests.
It was somewhat confusing to adapt the styles to our needs as I had to examine the provided Typeahead.scss file itself and create a style override file. It may be a little difficult to adapt later as we create a more cohesive theme in the future but I think it is manageable.

You should be able to select multiple options and have them show up as tokens for areas of interest and technologies of interest; you can only choose one option for the article level so there wouldn't be tokens showing up there.

I've stacked the forms on top of each other for now.
![image](https://github.com/cppsea/CS-Catalog/assets/98421648/a4229969-6aa5-499d-a895-ef0427722a5f)

