### PR TITLE
made changes to settings pages

### DIFF
--- a/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
+++ b/frontend/src/Components/Settings/Customizations/CustomizationsEdit.jsx
@@ -12,13 +12,17 @@ import { PencilFill } from "react-bootstrap-icons";
 import "../Settings.scss";
 import { Typeahead } from "react-bootstrap-typeahead";
 import ArrowMarker from "../../ArrowMarker/ArrowMarker";
-export default function CustomizationsEdit({}) {
-  //customization data
-  const [custData, setCustData] = useState({
-    interest_areas: [],
-    article_level: [],
+export default function CustomizationsEdit({
+  customerData = {
+    interest_areas: ["Artificial Intelligence"],
+    article_level: ["Beginner"],
     technologies: [],
-  });
+  },
+}) {
+  const [oldCustData, setOldCustData] = useState(customerData);
+
+  //customization data
+  const [custData, setCustData] = useState(customerData);
 
   //state of options for each data
   const [interestAreasOptions, setInterestAreasOptions] = useState([]);
@@ -45,6 +49,18 @@ export default function CustomizationsEdit({}) {
     technologies: false,
   });
 
+  //resets changes, edit modes, error messages
+  const resetChanges = () => {
+    setCustData(oldCustData);
+    setEditable({
+      interest_areas: false,
+      article_level: false,
+      technologies: false,
+    });
+    setErrorMessages({});
+    setIsDataChanged(false);
+  };
+
   // handle submit
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -52,7 +68,7 @@ export default function CustomizationsEdit({}) {
   };
 
   return (
-    <Container className="my-3">
+    <Container className="my-3 mx-0" fluid>
       <h2 className="settings-header">Customizations</h2>
       <div className="settings-divider"></div>
       <Form noValidate onSubmit={handleSubmit}>
@@ -111,25 +127,23 @@ export default function CustomizationsEdit({}) {
             />
           </Col>
         </Row>
-        {isDataChanged && (
+        {/*Show if any are in edit mode*/}
+        {Object.values(editable).some((ele) => ele) && (
           <Stack
             direction="horizontal"
             gap={3}
             className="mt-3 justify-content-end "
           >
+            {/*only show save if there are actual changes*/}
+            {isDataChanged && (
+              <div>
+                <Button className="settings-confirm-button" type="submit">
+                  Save
+                </Button>
+              </div>
+            )}
             <div>
-              <Button className="settings-confirm-button" type="submit">
-                Save
-              </Button>
-            </div>
-            <div>
-              <Button
-                className="settings-cancel-button"
-                onClick={() => {
-                  setIsDataChanged(false);
-                  window.location.reload();
-                }}
-              >
+              <Button className="settings-cancel-button" onClick={resetChanges}>
                 Cancel
               </Button>
             </div>

--- a/frontend/src/Components/Settings/Profile/ProfileEdit.jsx
+++ b/frontend/src/Components/Settings/Profile/ProfileEdit.jsx
@@ -14,14 +14,17 @@ import "../Settings.scss";
 import * as auth from "../../auth/auth";
 import PasswordChangeModal from "./PasswordChangeModal";
 import ArrowMarker from "../../ArrowMarker/ArrowMarker";
-export default function ProfileEdit({}) {
-  const [profileData, setProfileData] = useState({
+export default function ProfileEdit({
+  profile = {
     fname: "Joe",
     lname: "",
     email: "jsmith@gmail.com",
     username: "jsmith10",
     password: "password",
-  });
+  },
+}) {
+  const [profileDataCopy, setProfileDataCopy] = useState(profile);
+  const [profileData, setProfileData] = useState(profile);
 
   // keep track of chnanges
   const [isDataChanged, setIsDataChanged] = useState(false);
@@ -51,6 +54,19 @@ export default function ProfileEdit({}) {
     });
   };
 
+  //resets changes, edit modes, error messages
+  const resetChanges = () => {
+    setProfileData(profileDataCopy);
+    setEditable({
+      fname: false,
+      lname: false,
+      email: false,
+      username: false,
+      password: false,
+    });
+    setErrorMessages({});
+    setIsDataChanged(false);
+  };
   // handle submit
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -75,7 +91,7 @@ export default function ProfileEdit({}) {
   };
 
   return (
-    <Container className="my-3">
+    <Container className="my-3 mx-0" fluid>
       <h2 className="settings-header">Profile</h2>
       <div className="settings-divider"></div>
 
@@ -298,25 +314,23 @@ export default function ProfileEdit({}) {
           </Row>
         </div>
 
-        {isDataChanged && (
+        {/*Show if any are in edit mode*/}
+        {Object.values(editable).some((ele) => ele) && (
           <Stack
             direction="horizontal"
             gap={3}
             className="mt-3 justify-content-end "
           >
+            {/*only show save if there are actual changes*/}
+            {isDataChanged && (
+              <div>
+                <Button className="settings-confirm-button" type="submit">
+                  Save
+                </Button>
+              </div>
+            )}
             <div>
-              <Button className="settings-confirm-button" type="submit">
-                Save
-              </Button>
-            </div>
-            <div>
-              <Button
-                className="settings-cancel-button"
-                onClick={() => {
-                  setIsDataChanged(false);
-                  window.location.reload();
-                }}
-              >
+              <Button className="settings-cancel-button" onClick={resetChanges}>
                 Cancel
               </Button>
             </div>

--- a/frontend/src/Components/Settings/SavedArticles/ConfirmDeleteModal.jsx
+++ b/frontend/src/Components/Settings/SavedArticles/ConfirmDeleteModal.jsx
@@ -8,23 +8,21 @@ export default function ConfirmDeleteModal({
 }) {
   return (
     <Modal show={isOpen} onHide={handleClose} centered>
-      <Modal.Header closeButton className="border-0" />
-      <ModalBody>
+      <Modal.Header
+        closeButton
+        className="settings-articles-bookmark-modal border-0"
+      />
+      <ModalBody className="settings-articles-bookmark-modal">
         <h5 className="text-center">
           Are you sure you want to remove the article(s) you selected?
         </h5>
         <div className="d-flex justify-content-between mt-4">
-          <Button
-            className="border-0 text-dark fw-medium"
-            style={{ backgroundColor: "#B9B2B2" }}
-            onClick={handleClose}
-          >
+          <Button className="settings-cancel-button" onClick={handleClose}>
             Cancel
           </Button>
 
           <Button
-            className="border-0 text-dark fw-medium"
-            style={{ backgroundColor: "#24BEEF" }}
+            className="settings-confirm-button"
             type="submit"
             onClick={() => {
               handleClose();

--- a/frontend/src/Components/Settings/SavedArticles/SavedArticles.jsx
+++ b/frontend/src/Components/Settings/SavedArticles/SavedArticles.jsx
@@ -102,7 +102,7 @@ export default function SavedArticles() {
     console.log(searchbarText);
   };
   return (
-    <Container className="my-3 h-100 d-flex flex-column">
+    <Container className="my-3 h-100 d-flex flex-column m-0" fluid>
       <h2 className="settings-header">Saved Articles</h2>
       <div className="settings-divider"></div>
 

--- a/frontend/src/Components/Settings/Settings.scss
+++ b/frontend/src/Components/Settings/Settings.scss
@@ -48,6 +48,9 @@
 //settings edit button
 .settings-edit-button {
   border-width: 0 !important;
+  display: flex !important;
+  justify-content: center;
+  align-items: center;
   &:hover {
     background-color: $primary !important;
     color: white !important;
@@ -152,6 +155,9 @@
   .settings-divider {
     border-color: $divider-dark;
   }
+  .settings-articles-bookmark-modal {
+    background: $primary-bg-dark;
+  }
 }
 
 @include color-mode(light) {
@@ -173,5 +179,8 @@
 
   .settings-divider {
     border-color: $divider-light;
+  }
+  .settings-articles-bookmark-modal {
+    background: $primary-bg-light;
   }
 }

--- a/frontend/src/pages/Settings/SettingsPage.scss
+++ b/frontend/src/pages/Settings/SettingsPage.scss
@@ -17,6 +17,6 @@
 
 .settings-navbar-column {
   @include media-breakpoint-up(lg) {
-    max-width: 300px !important;
+    max-width: 400px !important;
   }
 }


### PR DESCRIPTION
I've made some fixes to the settings page

# Changes
- I've made it so there is no longer a huge gap between the settings navbar and the settings form on large screens.
- I've added theming to the saved articles confirmation article which I forgot to do before
- I've made it so that the cancel button will appear when editing mode is entered as Jeff suggested, and the save button will only appear when actual changes are made
- the pencil icon is now centered inside the edit button
- I've added a state that contains data before it was changed, and a resetChanges function for the cancel button that will do so using that state containing the original data, and removed forcing a reload when the cancel button is clicked. I believe this is necessary since we want to avoid making the user waste more time by forcing a reload when it isn't necessary.

# What you should see

- removed gap
![image](https://github.com/cppsea/CS-Catalog/assets/98421648/567f587f-623c-4439-aa5f-012d3122040b)

- Upon entering edit mode 
![image](https://github.com/cppsea/CS-Catalog/assets/98421648/85011f66-5841-4097-b6a2-9b4714a80fed)

- Upon actually making changes
![image](https://github.com/cppsea/CS-Catalog/assets/98421648/1c15cb99-54c9-48b4-bea6-4157396b04b4)

- themed saved articles modal
![image](https://github.com/cppsea/CS-Catalog/assets/98421648/647b89a2-d0eb-4f55-ad1e-5619e2701750)

# Other thoughts
I know Jeff recommended a different color of #B0B0B0 for editable text, but I tried it out and in my opinion it looks way too close to the background and makes it harder to distinguish. I think keeping it white is good for that purpose unless there's another color that would work just as well.

If there are any changes that yall think should be done feel free to point them out and I'll try to address them.
