### PR TITLE
created related tags section for article results page

### DIFF
--- a/frontend/src/Components/ArticleResult/SideSections/ArticleResultSideSection.scss
+++ b/frontend/src/Components/ArticleResult/SideSections/ArticleResultSideSection.scss
@@ -1,0 +1,31 @@
+@import "bootstrap/scss/bootstrap-grid.scss";
+@import "bootstrap/scss/grid";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/functions";
+@import "../../../scss/variables";
+
+
+.article-results-side-section-title {
+  margin-bottom: 1rem;
+  font-size: calc(0.8rem + 0.5vw);
+  font-weight: 600;
+  @include media-breakpoint-up(sm) {
+    font-size: calc(1.2rem + 0.5vw);
+  }
+}
+
+.article-results-section-content {
+  padding-left: 10px;
+}
+
+@include color-mode(light) {
+  .article-results-side-section-title {
+    color: $primary-text-light;
+  }
+}
+@include color-mode(dark) {
+  .article-results-side-section-title {
+    color: $primary-text-dark;
+  }
+}

--- a/frontend/src/Components/ArticleResult/SideSections/RelatedTopicTags/RelatedTopicTags.jsx
+++ b/frontend/src/Components/ArticleResult/SideSections/RelatedTopicTags/RelatedTopicTags.jsx
@@ -1,0 +1,31 @@
+import "./RelatedTopicTags.scss";
+import "../ArticleResultSideSection.scss";
+//tags : array of tag objects
+export default function RelatedTags({ tags }) {
+  return (
+    <div
+      className="article-results-side-section"
+      id="related-topic-tags-section"
+    >
+      <h3
+        id="related-topic-tags-section-title"
+        className="article-results-side-section-title"
+      >
+        Related Topics
+      </h3>
+      <div className="article-results-section-content related-topic-tags-container">
+        {tags.map((tag) => {
+          return (
+            <span
+              key={tag.label}
+              id={tag.label + "-topic"}
+              className="related-topic-tag"
+            >
+              {tag.label}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/Components/ArticleResult/SideSections/RelatedTopicTags/RelatedTopicTags.scss
+++ b/frontend/src/Components/ArticleResult/SideSections/RelatedTopicTags/RelatedTopicTags.scss
@@ -1,0 +1,36 @@
+@import "bootstrap/scss/bootstrap-grid.scss";
+@import "bootstrap/scss/grid";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/functions";
+@import "../../../../scss/variables";
+.related-topic-tag {
+  background: $related-topic-tag-bg;
+  color: white;
+  border-radius: 20px;
+  padding: 5px 8px;
+  white-space: nowrap;
+  font-weight: 600;
+  font-size: calc(0.5rem + 0.1vw);
+  @include media-breakpoint-up(sm) {
+    font-size: calc(0.7rem + 0.1vw);
+  }
+
+  &:hover {
+    filter: brightness(1.2);
+    cursor: pointer;
+  }
+
+  &:active {
+    filter: brightness(0.8);
+    position: relative;
+    top: 1px;
+    cursor: auto;
+  }
+}
+
+.related-topic-tags-container {
+  display: flex;
+  flex-flow: wrap;
+  gap: 10px 8px;
+}

--- a/frontend/src/pages/ArticleList.jsx
+++ b/frontend/src/pages/ArticleList.jsx
@@ -1,25 +1,28 @@
 import { useEffect, useState } from "react";
-import { Card, Stack } from "react-bootstrap";
 import { useParams, useSearchParams } from "react-router-dom";
-import LinkedDescriptionBox from "../Components/LinkedDescriptionBox.jsx";
+import RelatedTags from "../Components/ArticleResult/SideSections/RelatedTopicTags/RelatedTopicTags.jsx";
 
-export default function ArticleList({  }) {
-  const [data,setData] = useState()
-  const [searchParams, setSearchParams] = useSearchParams()
-  const [specificArticle, setSpecificArticle] = useState()
-  const titleQuery = searchParams.get("title")
+const dummy_topic_tags = [
+  { label: "Deep Learning" },
+  { label: "Artifical Intelligence" },
+  { label: "Computer Vision" },
+  { label: "Data Science" },
+];
+export default function ArticleList({}) {
+  const [data, setData] = useState();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [specificArticle, setSpecificArticle] = useState();
+  const titleQuery = searchParams.get("title");
   //console.log(titleQuery);
 
-  useEffect(()=>
-  {
+  useEffect(() => {
     fetch(`http://localhost:3002/api/articles/?title=${titleQuery}`)
-      .then((res) => res.json()
-      .then(data => setData(data)))
-      .catch((error) =>{
+      .then((res) => res.json().then((data) => setData(data)))
+      .catch((error) => {
         console.error("error fetching data");
-      })
+      });
 
-  /**     if(data && data.length > 0 ){
+    /**     if(data && data.length > 0 ){
         const specificArticleId = data[0].id;
       fetch(`http://localhost:3002/api/articles/${specificArticleId}`)
         .then((res) => res.json())
@@ -31,11 +34,11 @@ export default function ArticleList({  }) {
           console.error("error fetching specific article");
         });
       } */
-  },[titleQuery, setSearchParams])
+  }, [titleQuery, setSearchParams]);
 
   const { id } = useParams();
 
- /* const fetchArticle = async () => {
+  /* const fetchArticle = async () => {
     fetch(`http://localhost:3002/api/articles/?title=${titleQuery}`)
     .then((res) => res.json())
     .then((data) => {
@@ -46,106 +49,10 @@ export default function ArticleList({  }) {
       console.error("Error fetching item data:", error);
     });
   } */
-  
 
-  if (data == undefined )
-  {
-    return <>loading...</>
-  }
-  console.log(data);
   return (
-    <>
-      <div className="mt-5" >
-        <Stack gap={3}>
-          <div>
-            <Card style={{ border: "none" }}>
-              <Card.Body>
-                <h4 className="ps-4">Search Results: "{titleQuery}"</h4>
-              </Card.Body>
-            </Card>
-          </div>
-          {data.map((item) => (
-            <div>
-              <LinkedDescriptionBox
-              title={item.title}
-              id={item.id}
-              variant="secondary">
-                {item.description}
-              </LinkedDescriptionBox>
-            </div>
-          ))}
-          {/* <div>
-            <LinkedDescriptionBox
-              title={"Intro to Machine Learning"}
-              variant="secondary"
-            >
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-              reprehenderit in voluptate velit esse cillum dolore eu fugiat
-              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </LinkedDescriptionBox>
-          </div>
-          <div>
-            <LinkedDescriptionBox
-              title={"Regressional Analysis"}
-              variant="secondary"
-            >
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-              reprehenderit in voluptate velit esse cillum dolore eu fugiat
-              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </LinkedDescriptionBox>
-          </div>
-          <div>
-            <LinkedDescriptionBox
-              title={"Regressional Analysis"}
-              variant="secondary"
-            >
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-              reprehenderit in voluptate velit esse cillum dolore eu fugiat
-              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </LinkedDescriptionBox>
-          </div>
-          <div>
-            <LinkedDescriptionBox
-              title={"Regressional Analysis"}
-              variant="secondary"
-            >
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-              reprehenderit in voluptate velit esse cillum dolore eu fugiat
-              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </LinkedDescriptionBox>
-          </div>
-          <div>
-            <LinkedDescriptionBox
-              title={"Regressional Analysis"}
-              variant="secondary"
-            >
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-              reprehenderit in voluptate velit esse cillum dolore eu fugiat
-              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </LinkedDescriptionBox>
-          </div> */}
-        </Stack>
-      </div>
-    </>
+    <div className="flex-grow-1">
+      <RelatedTags tags={dummy_topic_tags} />
+    </div>
   );
 }

--- a/frontend/src/scss/variables/_variables-universal.scss
+++ b/frontend/src/scss/variables/_variables-universal.scss
@@ -5,6 +5,9 @@ $link-text: #2c6ae1;
 $header-footer-bg: #312f2f;
 $header-text: #f4e4bb;
 
+//Related Topic Tags
+$related-topic-tag-bg: #2c6ae1;
+
 //popover
 $popover-header-bg: #063ba1;
 $popover-body-bg: #2c6ae1;
@@ -19,8 +22,8 @@ $settings-article-search-bar: #d5d5d5;
 
 //Sign Pages
 $sign-page-title: #366092;
-$welcome-section-link: #4E8AD1;
-$sign-input-placeholder: #6B6565;
+$welcome-section-link: #4e8ad1;
+$sign-input-placeholder: #6b6565;
 
 //fonts
 @font-face {


### PR DESCRIPTION
I have implemented the related topics tags section for the article results page. The component accepts an array of tag objects, and displays the label property of each object on the screen. There is also styling for hovering over and clicking on a tag, but since we dont have any topic pages or anything like that implemented this is purely cosmetic for now. You should be able to see this by 

# What you should see
![image](https://github.com/cppsea/CS-Catalog/assets/98421648/b8299da8-49da-4d8d-aa1d-79f3055b18b7)
![image](https://github.com/cppsea/CS-Catalog/assets/98421648/411a6c70-6f80-45f0-acb5-e77d9c6e1534)
