### PR TITLE
Refactoring article results page based on the new UI changes

### DIFF
--- a/frontend/src/Components/Article/ArticleComponents.scss
+++ b/frontend/src/Components/Article/ArticleComponents.scss
@@ -48,8 +48,8 @@
 }
 
 .article-bookmark {
-  margin-left: 10px;
-  font-size: calc(0.8rem + 0.3vw);
+  
+  font-size: calc(1rem + 0.5vw + 0.5vh);
 
   &:hover {
     cursor: pointer;
@@ -224,7 +224,12 @@
   .table-contents-marker {
     background: $arrow-marker-light;
   }
-  .article-title,
+
+  .article-title {
+    color: $article-header-light;
+  }
+
+ 
   .related-topics-heading,
   .topic-list-title,
   .section-header,
@@ -250,7 +255,10 @@
     background: $arrow-marker-dark;
   }
 
-  .article-title,
+  .article-title {
+    color: $article-header-dark;
+  }
+
   .related-topics-heading,
   .topic-list-title,
   .section-header,

--- a/frontend/src/Components/Article/ArticleHeader/ArticleHeader.jsx
+++ b/frontend/src/Components/Article/ArticleHeader/ArticleHeader.jsx
@@ -27,7 +27,11 @@ export default function ArticleHeader({
 }) {
   return (
     <Stack gap={2}>
-      <ArticleHeaderTitle title={title} />
+      <ArticleHeaderTitle
+        title={title}
+        isBookmarked={isBookmarked}
+        bookmarkToggler={bookmarkToggler}
+      />
       <ArticleHeaderDesc desc={description} />
       <ArticleHeaderAuthorDate
         author={author}

--- a/frontend/src/Components/Article/ArticleHeader/ArticleHeaderAuthorDate.jsx
+++ b/frontend/src/Components/Article/ArticleHeader/ArticleHeaderAuthorDate.jsx
@@ -1,25 +1,10 @@
-import { Bookmark, BookmarkFill } from "react-bootstrap-icons";
-
 //component for article author and date, also contains bookmark
-export default function ArticleHeaderAuthorDate({
-  author,
-  date,
-  isBookmarked,
-  bookmarkToggler,
-}) {
+export default function ArticleHeaderAuthorDate({ author, date }) {
   return (
     <div className="d-flex flex-column fst-italic article-header-author-date">
       <span>By {author}</span>
       <div className="d-flex">
         <span>Published {date}</span>
-        {isBookmarked ? (
-          <Bookmark className="article-bookmark" onClick={bookmarkToggler} />
-        ) : (
-          <BookmarkFill
-            className="article-bookmark"
-            onClick={bookmarkToggler}
-          />
-        )}
       </div>
     </div>
   );

--- a/frontend/src/Components/Article/ArticleHeader/ArticleHeaderTitle.jsx
+++ b/frontend/src/Components/Article/ArticleHeader/ArticleHeaderTitle.jsx
@@ -1,10 +1,21 @@
 import { Stack } from "react-bootstrap";
 
+import { Bookmark, BookmarkFill } from "react-bootstrap-icons";
+
 //component for article title
-export default function ArticleHeaderTitle({ title }) {
+export default function ArticleHeaderTitle({
+  title,
+  isBookmarked,
+  bookmarkToggler,
+}) {
   return (
-    <Stack direction="horizontal">
-      <h1 className="fw-bold article-title">{title}</h1>
+    <Stack direction="horizontal" gap={2}>
+      {isBookmarked ? (
+        <Bookmark className="article-bookmark" onClick={bookmarkToggler} />
+      ) : (
+        <BookmarkFill className="article-bookmark" onClick={bookmarkToggler} />
+      )}
+      <h1 className="text-uppercase fw-bold article-title">{title}</h1>
     </Stack>
   );
 }

--- a/frontend/src/Components/Article/ArticleHeader/ArticleHeaderTitle.jsx
+++ b/frontend/src/Components/Article/ArticleHeader/ArticleHeaderTitle.jsx
@@ -11,9 +11,9 @@ export default function ArticleHeaderTitle({
   return (
     <Stack direction="horizontal" gap={2}>
       {isBookmarked ? (
-        <Bookmark className="article-bookmark" onClick={bookmarkToggler} />
-      ) : (
         <BookmarkFill className="article-bookmark" onClick={bookmarkToggler} />
+      ) : (
+        <Bookmark className="article-bookmark" onClick={bookmarkToggler} />
       )}
       <h1 className="text-uppercase fw-bold article-title">{title}</h1>
     </Stack>

--- a/frontend/src/Components/Article/Topics/RelatedTopicsList.jsx
+++ b/frontend/src/Components/Article/Topics/RelatedTopicsList.jsx
@@ -15,7 +15,7 @@ import TopicList from "./TopicList";
 export default function RelatedTopicsList({ topicLists }) {
   return (
     <Stack>
-      <h3 className="related-topics-heading mb-3">Related Topics</h3>
+      <h3 className="text-uppercase related-topics-heading mb-3">Related Topics</h3>
       <Stack gap={3}>
         {topicLists.map(({ topicCategory, topicList }) => (
           <TopicList

--- a/frontend/src/Components/ArticleResults/ArticleResult/ArticleResult.jsx
+++ b/frontend/src/Components/ArticleResults/ArticleResult/ArticleResult.jsx
@@ -12,6 +12,8 @@ export default function ArticleResult({ article, bookmarkToggler }) {
     <div className="article-result">
       <div className="article-result-image-container">
         <Image src={article.image} className="article-result-image" />
+      </div>
+      <div>
         {article.isBookmarked ? (
           <BookmarkFill
             className="article-result-bookmark"
@@ -24,7 +26,6 @@ export default function ArticleResult({ article, bookmarkToggler }) {
           />
         )}
       </div>
-
       <div className="article-result-text">
         <h3 className="article-result-title" onClick={articleNavigate}>
           {article.title}

--- a/frontend/src/Components/ArticleResults/ArticleResult/ArticleResult.scss
+++ b/frontend/src/Components/ArticleResults/ArticleResult/ArticleResult.scss
@@ -6,26 +6,20 @@
 @import "../../../scss/variables";
 /*overall article result container*/
 .article-result {
-  display: grid;
-  grid-template-columns: 1fr 6fr;
-  gap: 20px;
+  display: flex;
+  gap: 10px;
   height: 100px;
   @include media-breakpoint-up(sm) {
     height: 150px;
-  }
-  @include media-breakpoint-up(lg) {
-    grid-template-columns: 250px 5fr;
   }
 }
 
 /*image*/
 .article-result-image-container {
   width: fit-content;
-  position: relative;
   display: flex;
   height: inherit;
   justify-content: center;
-  margin: auto;
 }
 
 .article-result-image {
@@ -41,10 +35,6 @@
   }
 }
 .article-result-bookmark {
-  position: absolute;
-  transform: rotate(-90deg);
-  top: 0;
-  right: -10px;
   width: fit-content;
 
   &:hover {
@@ -70,6 +60,7 @@
 
 .article-result-title {
   font-weight: 600;
+  text-transform: uppercase;
   margin-bottom: 0 !important;
   font-size: calc(0.8rem + 0.5vw);
   @include media-breakpoint-up(sm) {

--- a/frontend/src/Components/ArticleResults/SideSections/RelatedTopicTags/RelatedTopicTags.jsx
+++ b/frontend/src/Components/ArticleResults/SideSections/RelatedTopicTags/RelatedTopicTags.jsx
@@ -9,7 +9,7 @@ export default function RelatedTags({ tags }) {
     >
       <h3
         id="related-topic-tags-section-title"
-        className="article-results-side-section-title"
+        className="text-uppercase article-results-side-section-title"
       >
         Related Topics
       </h3>

--- a/frontend/src/pages/ArticleResultsPage/ArticleResultsPage.jsx
+++ b/frontend/src/pages/ArticleResultsPage/ArticleResultsPage.jsx
@@ -72,7 +72,7 @@ export default function ArticleResultsPage({}) {
       <Row>
         <Col xs={{ order: 1 }} md={{ order: 0, span: 9 }}>
           <h2 className="article-results-title mb-5">
-            Results for{" "}
+            Displaying results for{" "}
             <span className="article-results-title-query">"{titleQuery}"</span>
           </h2>
           <ArticleResultsList

--- a/frontend/src/pages/ArticleResultsPage/ArticleResultsPage.jsx
+++ b/frontend/src/pages/ArticleResultsPage/ArticleResultsPage.jsx
@@ -51,7 +51,7 @@ export default function ArticleResultsPage({}) {
               "https://emeritus.org/in/wp-content/uploads/sites/3/2023/03/types-of-machine-learning.jpg.optimal.jpg";
             articleObject.author = "jeff";
             articleObject.date = "October 24, 2023";
-            articleObject.isBookmarked = true;
+            articleObject.isBookmarked = false;
           });
           setArticles(dataCopy);
         })


### PR DESCRIPTION
This is a PR for refactoring the `Article Results` page
## What you should see:
### Search Result page:
![image](https://github.com/cppsea/CS-Catalog/assets/121127992/2724870d-3ded-4c35-8884-780f5ea4087e)
### Article View page
![image](https://github.com/cppsea/CS-Catalog/assets/121127992/915c618e-0b29-44ce-9cdf-391d0995dd4d)
